### PR TITLE
Issue #SB-11612 chore: gzip added to bundle files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bower-resolve-webpack-plugin": "*",
     "brotli-gzip-webpack-plugin": "*",
     "clean-webpack-plugin": "^0.1.19",
-    "compression-webpack-plugin": "*",
+    "compression-webpack-plugin": "^2.0.0",
     "copy-webpack-plugin": "^4.5.2",
     "cpy": "7.0.1",
     "css-loader": "^0.28.11",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ const extract = require('extract-zip');
 const { exec } = require('child_process');
 const cpy = require('cpy');
 const gulp = require('gulp');
+const CompressionPlugin = require('compression-webpack-plugin');
 
 
 /**
@@ -312,6 +313,13 @@ module.exports = (env, argv) => {
                     }
                 },
                 canPrint: true
+            }),
+            new CompressionPlugin({
+                algorithm: 'gzip',
+                minRatio: 1,
+                filename(fileIterator){
+                    return `${fileIterator.path}.gz`
+                }
             }),
             new ZipPlugin({
                 path: path.join(__dirname, '.'),


### PR DESCRIPTION
- [Issue Link](https://project-sunbird.atlassian.net/browse/SB-11612)
- Not zipping image and woff2 files. As compressing these files will only result in, an increase of final bundle size **with out** providing compression benefits.