### PR TITLE
Issue #SH-458 fix: Search by course id or name is not working on add resource page while adding course/resoure to units

### DIFF
--- a/app/scripts/collectioneditor/service/collection-service.js
+++ b/app/scripts/collectioneditor/service/collection-service.js
@@ -431,11 +431,11 @@ org.ekstep.services.collectionService = new (Class.extend({
 					ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'rename', false)
 				} else {
 					ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'rename', nodeType.editable)
-					ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'addChild', (nodeType.addType === 'Editor'))
+					ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'addChild', (_.includes(nodeType.addType, 'Editor')))
 					if (node.getLevel() >= config.rules.levels - 1) {
 						ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'addChild', false)
 					}
-					ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'addSibling', (!!(!node.data.root && nodeType.addType === 'Editor')))
+					ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'addSibling', (!!(!node.data.root && (_.includes(nodeType.addType, 'Editor')))))
 					ecEditor.jQuery('#collection-tree').contextmenu('enableEntry', 'addLesson', nodeType.editable)
 				}
 				return node.setActive()
@@ -635,7 +635,7 @@ org.ekstep.services.collectionService = new (Class.extend({
 	getObjectTypeByAddType: function (addType) {
 		var categoryList = []
 		_.find(this.config.rules.objectTypes, function (obj) {
-			if (obj.addType === addType) {
+			if (_.includes(obj.addType, addType)) {
 				categoryList.push(obj.type)
 			}
 		})


### PR DESCRIPTION
Issue #SH-458 fix: Search by course id or name is not working on add resource page while adding course/resoure to units

**Scenarios**:-

1. If the addType of the node is "Editor", the add child option should show in list option
2. If the addType of the node is "Browser", then an add child option should not show in list option
3. In a resource browser - If the addType of the node is "Editor", the search should not show the result for this node type
4. In a resource browser - If the addType of the node is "Browser", the search should show the result for this node type
5. If the addType of the node is ["Editor", "Browser"], the add child option should show in list option
6. In a resource browser - If the addType of the node is ["Editor", "Browser"], the search should show the result for this node type
7. In an editor configuration - if user set the addType property in a string, as per the value above 1,2,3,4 scenarios should work
8. In an editor configuration - if the user set the addType property in an array, as per the value above 1,2,3,4  scenarios should work

